### PR TITLE
Suppress the following warning when running qemu:

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.riscv32imac-unknown-none-elf]
-runner = "qemu-system-riscv32 -nographic -machine sifive_u -kernel"
+runner = "qemu-system-riscv32 -nographic -bios none -machine sifive_u -kernel"
 rustflags = [
   "-C", "link-arg=-Tlinker.ld",
 ]


### PR DESCRIPTION
```bash
root@4c1c2298d6f1:/workspaces/riscv64imac-hello-rs# CC=riscv64-unknown-elf-gcc cargo run
   Compiling riscv64imac-hello-rs v0.1.0 (/workspaces/riscv64imac-hello-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 0.43s
     Running `qemu-system-riscv32 -nographic -machine sifive_u -kernel target/riscv32imac-unknown-none-elf/debug/riscv64imac-hello-rs`
qemu-system-riscv32: warning: No -bios option specified. Not loading a firmware.
qemu-system-riscv32: warning: This default will change in a future QEMU release. Please use the -bios option to avoid breakages when this happens.
qemu-system-riscv32: warning: See QEMU's deprecation documentation for details.
Hello from Rust!QEMU: Terminated
```